### PR TITLE
ci: change capitalization of secret

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
       # Label used to access the service container
       exist:
         env: 
-          tuttle_token_tuttle_sample_data: ${{ secrets.tuttle_token_tuttle_sample_data }} 
+          tuttle_token_tuttle_sample_data: ${{ secrets.TUTTLE_TOKEN_TUTTLE_SAMPLE_DATA }} 
         image: existdb/existdb:${{ matrix.exist-version }}
         ports:
           - 8443:8443

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
       # Label used to access the service container
       exist:
         env: 
-          tuttle_token_tuttle_sample_data: ${{ secrets.TUTTLE_TOKEN_TUTTLE_SAMPLE_DATA }} 
+          tuttle_token_tuttle_sample_data: ${{ secrets.TEST_TOKEN }} 
         image: existdb/existdb:${{ matrix.exist-version }}
         ports:
           - 8443:8443


### PR DESCRIPTION
refs #16 

No luck so far. neither capitalisation nor token expiry seem to be the problem.

-- update --

It seems to be a mixture of issues as with a different token and on release (eXist v6.2.0) it is obvious that the environment variable is available inside the docker container.

