### PR TITLE
improve GitHub API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ To initialize the project and load dependencies run
 
 | Run | Description |
 |---------|-------------|
-|```gulp build```|to just build Tuttle. |
-|```gulp install```|To build and install Tuttle in one go|
+|```npm run build```|to just build Tuttle. |
+|```npm run deploy```|To build and install Tuttle in one go|
 
 The resulting xar(s) are found in the root of the project.
 
@@ -45,49 +45,78 @@ Run tests  with ```npm test```
 
 Tuttle is configured in `data/tuttle.xml`. 
 
-### Gitservice configuration 
-@name is always the name of the destination collection.  It will be configured in `data/tuttle.xml`
+New with version 2.0.0:
 
-An example:
+A commented example configuration is available `data/tuttle-example-config.xml`.
+If you want to update tuttle your modified configuration file will be backed up to
+`/db/tuttle-backup/tuttle.xml` and restored on installation of the new version.
+
+Otherwise, when no back up of an existing config-file is found, the example configuration is copied to `data/tuttle.xml`.
+
+> [!TIP]
+> When migrating from an earlier version you can copy your existing configuration to the backup location:
+> `xmldb:copy-resource('/db/apps/tuttle/data', 'tuttle.xml', '/db/tuttle-backup', 'tuttle.xml')`
+
+### Repository configuration 
+
+The repositories to keep in sync with a gitservice are all listed under the repos-element.
+
+The name-attribute refers to the **destination collection** also known as the **target collection**.
+
+#### Collection
+
+An example: `<collection name="tuttle-sample-data">`
+The collection `/db/apps/tuttle-sample-data` is now considered to be kept in sync with a git repository.
+
 ```xml
-  <repos>
-    <collection name="tuttle-sample-data">
-        <default>true</default>
-        <type>github</type>
-        <baseurl>https://api.github.com/</baseurl>
-        <repo>tuttle-sample-data</repo>
-        <owner>tuttle-sample-data</owner>
-        <token></token>
-        <ref>master</ref>
-        <hookuser>admin</hookuser>
-        <hookpasswd></hookpasswd>
-    </collection>
-    
-   <collection name="tuttle-sample-gitlab">
-        <type>gitlab</type>
-        <baseurl>https://gitlab.com/api/v4/</baseurl>
-        <project-id>tuttle-sample-data</project-id>
-        <token>XXX</token>
-        <ref>master</ref>
-        <hookuser>admin</hookuser>
-        <hookpasswd></hookpasswd>
-    </collection>
-  </repos>
+<collection name="tuttle-sample-data">
+    <default>true</default>
+
+    <type>github</type>
+    <baseurl>https://api.github.com/</baseurl>
+
+    <repo>tuttle-sample-data</repo>
+    <owner>tuttle-sample-data</owner>
+
+    <token>a-personal-access-token</token>
+
+    <ref>a-branch</ref>
+
+    <hookuser>a-exist-user</hookuser>
+    <hookpasswd>that-users-password</hookpasswd>
+</collection>
 ```
 
 #### type
-Gitserver type:  'github' or 'gitlab'
 
-####  baseurl
-* For github the baseurl is always api.github.com
-* For gitlab the url can also be your private gitlab server egg 'https://gitlab.existsolutions.com/api/v4/'
+```xml
+<type>gitlab</type>
+```
 
-####  repo, owner and project-id
- * For github you have to specify the owner and the repo
- * For gitlab you have to specify the project-id of the repository
+There are two supported git services at the moment `github` and `gitlab`
 
-#### ref 
-Define the working branch of the git repository
+#### baseurl
+
+```xml
+<baseurl>https://api.server/</baseurl>
+```
+
+* For github the baseurl is `https://api.github.com/` or your github-enterprise API endpoint
+* For gitlab the baseurl is `https://gitlab.com/api/v4/` but can also be your private gitlab server egg 'https://gitlab.existsolutions.com/api/v4/'
+
+#### repo, owner and project-id
+
+* For github you **have to** specify the owner and the repo
+* For gitlab you **have to** specify the project-id of the repository
+
+
+#### ref
+
+```xml
+<ref>main</ref>
+```
+
+Defines the branch you want to track. 
 
 #### hookuser & hookpasswd
 
@@ -95,13 +124,12 @@ Define the working branch of the git repository
 
 If a token is specified Tuttle authenticates against GitHub or GitLab. When a token is not defined, Tuttle assumes a public repository without any authentication.
 
-It is also possible to pass the token via an environment variable. The name of the variable have to be  `tuttle_token_ + collection` (all dashes must be replaces by underscore). Example: `tuttle_token_tuttle_sample_data`
+> [!NOTE]
+> Be aware of the rate limits for unauthenticated requests
+> GitHub allows 60 unauthenticated requests per hour but 5,000 for authenticated requests
 
-Be aware of the rate limits
-* GitHub: 
-  * 60 unauthenticated requests per hour
-  * 5,000 authenticated requests per hour
-
+> [!TIP]
+> It is also possible to pass the token via an environment variable. The name of the variable have to be  `tuttle_token_ + collection` (all dashes must be replaces by underscore). Example: `tuttle_token_tuttle_sample_data`
 
 ##### Create API-Keys for Github / Gitlab
 
@@ -123,17 +151,22 @@ The dashboard can trigger a full deployment or an incremental update.
 Full deployment clones the repository from git and install it as a `.xar` file.
 With incremental update only the changes to the database collection are applied.
 
+> [!NOTE]
+> Tuttle is built to keep track of **data collections**
+
+> [!NOTE]
+> Tuttle is does not run pre- or post install scripts nor change the index configuration on incremental updates!
+
 ### Lets start
 
-1) customize the configuration (`modules/config.xql`)
+1) customize the configuration (`data/tuttle.xml`)
 2) click on 'full' to trigger a full deployment from git to existdb
 3) now you can update your collection with a click on 'incremental'
 
 Repositories from which a valid XAR (existing `expath-pkg.xml` and `repo.xml`) package can be generated are installed as a package, all others are created purely on the DB.
 
-**REMARK: Note that there may be index problems if a collection is not installed as a package.**
-
-**REMARK: Only use it with data collections**
+> [!NOTE]
+> Note that there may be index problems if a collection is not installed as a package.
 
 ## API
 
@@ -243,10 +276,9 @@ be obtained from the respective service.
 
 The key for the gitservice must be configured in Gitservice configuration as shown above.
 
+## Roadmap
 
-## DB to Git
-
-Will be implemented in release 2.0.0
+- [ ] DB to Git
 
 ## Honorable mentions:
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,23 @@ The resulting xar(s) are found in the root of the project.
 
 ## Testing
 
-To run the local test suite you need an instance of eXist running on `localhost:8080` and `npm` to be available in your path. 
-Run tests  with ```npm test```
+To run the local test suite you need an
+* instance of eXist running on `localhost:8080` and 
+* `npm` to be available in your path
+* a GitHub personal access token with read access to public repositories
+* a gitlab personal access token with read access to public repositories
+
+In CI these access tokens are read from environment variables.
+You can do the same with
+```bash
+export tuttle_token_tuttle_sample_data=<GITHUB_PAT>; \ 
+export tuttle_token_gitlab_sample_data=<GITLAB_PAT>; \ 
+path/to/startup.sh
+```
+
+Alternatively, you can modify `/db/apps/tuttle/data/tuttle.xml` _and_ `test/fixtures/alt-tuttle.xml` to include your tokens. But remember to never commit them!
+
+Run tests with ```npm test```
 
 ## Configuration
 

--- a/src/modules/api.xql
+++ b/src/modules/api.xql
@@ -277,7 +277,7 @@ declare function api:git-deploy($request as map(*)) as map(*) {
 
                 let $remove-staging := collection:remove($staging, true())
                 let $remove-lock := app:lock-remove($destination)
-
+                let $reindex := xmldb:reindex($destination)
                 return map {
                     "hash": config:deployed-sha($destination),
                     "message": "success"

--- a/src/modules/github.xql
+++ b/src/modules/github.xql
@@ -193,7 +193,8 @@ declare function github:incremental($config as map(*)) {
     let $writesha := app:write-sha($config?path, $sha)
     return map {
         'new': array{ $new },
-        'del': array{ $del }
+        'del': array{ $del },
+        'ignored': array{ $changes?ignored }
     }
 };
 

--- a/src/modules/github.xql
+++ b/src/modules/github.xql
@@ -162,7 +162,8 @@ declare function github:aggregate-filechanges ($changes as map(*), $next as map(
         map:put($changes, "new", ($changes?new[. ne $next?filename], $next?filename))
     case "renamed" return
         let $new := map:put($changes, "new", ($changes?new, $next?filename))
-        return map:put($new, "del", ($changes?del, $next?previous_filename))
+        (: account for files that existed, were removed in one commit and then reinstated by renaming a file :)
+        return map:put($new, "del", ($changes?del[. ne $next?filename], $next?previous_filename))
     case "removed" return
         (: ignore this document, if it was added _and_ removed in the same changeset :)
         if ($next?filename = $changes?new)

--- a/src/modules/github.xql
+++ b/src/modules/github.xql
@@ -102,7 +102,14 @@ declare function github:get-newest-commits($config as map(*)) as xs:string* {
     let $commits := github:get-raw-commits($config, 100)
     let $shas := array:for-each($commits, github:only-commit-shas#1)?*
     let $how-many := index-of($shas?1, $deployed) - 1
-    return reverse(subsequence($shas?2, 1, $how-many))
+    return
+        if (empty($how-many)) then (
+            error(
+                xs:QName("github:commit-not-found"),
+                'The deployed commit hash ' || $deployed || ' was not found in the list of commits on the remote.')
+        ) else (
+            reverse(subsequence($shas?2, 1, $how-many))
+        )
 };
 
 (:~


### PR DESCRIPTION
- incremental update reports ignored files
   Ignored files are expath-pkg.xml, repo.xml and all .xconf files.
   Files that would be ignored was already reported by the dry-run but not for the actual run.
   This allows for clients to act on that information and can, for instance, report that a full installation is necessary or that the index configuration has changed.

- handle edge-case when a file is modified and then renamed
  That would have left the old file in the connected collection dangling.
   Now every renamed file will be deleted.
   As another edge-case where a file is _added_ and then renamed would try to remove an non-existing file, `github:incremental-delete`

- incremental updates handles pages
   When a single commit changes more than 300 changed files than the request is paged. The github module will now handle these. 

- download of files larger than 1MB
   Files larger than 1 megabyte are not returned in the query for metadata directly. That means we cannot rely on this query alone.
   If the content is empty we use the 'download_url' property instead. 

For GitHub.com we can construct the file download URL to point to raw.githubusercontent.com and do not even need to query for metadata of a changed file first.