### PR TITLE
fix(github): condition in get-blob detects the default case

### DIFF
--- a/src/modules/github.xql
+++ b/src/modules/github.xql
@@ -221,7 +221,7 @@ declare variable $github:raw-usercontent-endpoint := "https://raw.githubusercont
  : https://raw.githubusercontent.com/<owner>/<repo>/<sha>/<path>
  :)
 declare %private function github:get-blob($config as map(*), $filename as xs:string, $sha as xs:string) {
-    if (not(starts-with($config?base-url, "https://api.github.com"))) then (
+    if (not(starts-with($config?baseurl, "https://api.github.com"))) then (
         (: for GitHub enterprise we have to query for the download url, this might return the contents directly :) 
         let $blob-url := github:repo-url($config) || "/contents/" || escape-html-uri($filename) || "?ref=" || $sha
         let $json := github:request-json($blob-url, $config?token)


### PR DESCRIPTION
The key in the collection configuration map is "baseurl" not "base-url".