### PR TITLE
Fix status codes and callbacks

### DIFF
--- a/src/api.json
+++ b/src/api.json
@@ -1,7 +1,7 @@
 {
     "openapi": "3.0.0",
     "info": {
-        "version": "1.1.1",
+        "version": "1.2.0",
         "title": "Tuttle API",
         "description": "API for Tuttle Git integration"
     },
@@ -51,8 +51,8 @@
                     }
                 ],
                 "responses": {
-                    "200":{
-                        "description": "JSON dump of request",
+                    "200": {
+                        "description": "Following hash was pulled into which collection",
                         "content": {
                             "application/json": {
                                 "schema":{
@@ -60,6 +60,30 @@
                                     "properties": {
                                         "message":{
                                             "type": "string"
+                                        },
+                                        "hash": {
+                                            "type": "string"
+                                        },
+                                        "collection": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Something went wrong",
+                        "content": {
+                            "application/json": {
+                                "schema":{
+                                    "type": "object",
+                                    "properties": {
+                                        "message":{
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "object"
                                         }
                                     }
                                 }
@@ -85,15 +109,36 @@
                     }
                 ],
                 "responses": {
-                    "200":{
-                        "description": "JSON dump of request",
+                    "200": {
+                        "description": "Following hash was deployed",
                         "content": {
                             "application/json": {
                                 "schema":{
                                     "type": "object",
                                     "properties": {
-                                        "hash":{
+                                        "message":{
                                             "type": "string"
+                                        },
+                                        "hash": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Something went wrong",
+                        "content": {
+                            "application/json": {
+                                "schema":{
+                                    "type": "object",
+                                    "properties": {
+                                        "message":{
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "object"
                                         }
                                     }
                                 }
@@ -105,7 +150,7 @@
         },
         "/git/": {
             "get": {
-                "summary": "Fetch git repo to staging collection",
+                "summary": "Fetch default git repo to staging collection",
                 "x-constraints": {
                     "groups": ["dba"]
                 },
@@ -115,21 +160,45 @@
                         "name": "hash",
                         "in": "query",
                         "required": false,
-                        "schema":{
+                        "schema": {
                             "type": "string"
                         }
                     }
                 ],
                 "responses": {
-                    "200":{
-                        "description": "JSON dump of request",
+                    "200": {
+                        "description": "Following hash was pulled into which collection",
                         "content": {
                             "application/json": {
-                                "schema":{
+                                "schema": {
                                     "type": "object",
                                     "properties": {
-                                        "message":{
+                                        "message": {
                                             "type": "string"
+                                        },
+                                        "hash": {
+                                            "type": "string"
+                                        },
+                                        "collection": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Something went wrong",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "object"
                                         }
                                     }
                                 }
@@ -145,15 +214,36 @@
                 },
                 "operationId": "api:git-deploy",
                 "responses": {
-                    "200":{
-                        "description": "JSON dump of request",
+                    "200": {
+                        "description": "Following hash was deployed",
                         "content": {
                             "application/json": {
-                                "schema":{
+                                "schema": {
                                     "type": "object",
                                     "properties": {
-                                        "hash":{
+                                        "message": {
                                             "type": "string"
+                                        },
+                                        "hash": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Something went wrong",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "object"
                                         }
                                     }
                                 }
@@ -175,7 +265,7 @@
                         "name": "collection",
                         "in":  "path",
                         "required": true,
-                        "schema":{
+                        "schema": {
                             "type": "string"
                         }
                     },
@@ -183,14 +273,14 @@
                         "name": "dry",
                         "in":  "query",
                         "required": false,
-                        "schema":{
+                        "schema": {
                             "type": "boolean",
                             "default": false
                         }
                     }
                 ],
                 "responses": {
-                    "200":{
+                    "200": {
                         "description": "Result of the incremental update",
                         "content": {
                             "application/json": {
@@ -208,7 +298,7 @@
                             }
                         }
                     },
-                    "403":{
+                    "403": {
                         "description": "Request cannot run",
                         "content": {
                             "application/json": {
@@ -217,6 +307,24 @@
                                     "properties" : {
                                         "message" : {
                                             "type" : "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Something went wrong",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "object"
                                         }
                                     }
                                 }
@@ -245,7 +353,7 @@
                     }
                 ],
                 "responses": {
-                    "200":{
+                    "200": {
                         "description": "Result of the incremental update of the default collection",
                         "content": {
                             "application/json": {
@@ -263,7 +371,7 @@
                             }
                         }
                     },
-                    "403":{
+                    "403": {
                         "description": "Request cannot run",
                         "content": {
                             "application/json": {
@@ -277,11 +385,29 @@
                                 }
                             }
                         }
+                    },
+                    "500": {
+                        "description": "Something went wrong",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "object"
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
         },
-        "/git/{collection}/hash":{
+        "/git/{collection}/hash": {
             "get": {
                 "summary": "Get remote and local hash",
                 "x-constraints": {
@@ -321,6 +447,21 @@
                                 }
                             }
                         }
+                    },
+                    "500": {
+                        "description": "Something went wrong",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -334,7 +475,7 @@
                 "operationId": "api:get-hash",
                 "responses": {
                     "200": {
-                        "description": "GIT Hash",
+                        "description": "git hashes",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -350,6 +491,21 @@
                                         "local-staging-hash":{
                                             "type": "string",
                                             "nullable": true
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Something went wrong",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
                                         }
                                     }
                                 }
@@ -387,11 +543,29 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "GIT commits",
+                        "description": "List of last git commits",
                         "content": {
                             "application/json": {
                                 "schema": {
                                     "type": "array"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Something went wrong",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "object"
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -411,7 +585,7 @@
                         "name": "count",
                         "in": "query",
                         "required": false,
-                        "schema":{
+                        "schema": {
                             "type": "integer",
                             "default": 20
                         }
@@ -419,11 +593,29 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "GIT commits",
+                        "description": "List of last git commits",
                         "content": {
                             "application/json": {
                                 "schema": {
                                     "type": "array"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Something went wrong",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "object"
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -447,14 +639,32 @@
                 ],
                 "responses": {
                     "200":{
-                        "description": "JSON dump of request",
+                        "description": "Result of the action",
                         "content": {
                             "application/json": {
-                                "schema":{
+                                "schema": {
                                     "type": "object",
                                     "properties": {
-                                        "message":{
+                                        "message": {
                                             "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Something went wrong",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "object"
                                         }
                                     }
                                 }
@@ -469,15 +679,33 @@
                 "summary": "Trigger incremental update via Gitlab/Github",
                 "operationId": "api:hook",
                 "responses": {
-                    "200":{
-                        "description": "JSON dump of request",
+                    "200": {
+                        "description": "Result of the action",
                         "content": {
                             "application/json": {
-                                "schema":{
+                                "schema": {
                                     "type": "object",
                                     "properties": {
-                                        "message":{
+                                        "message": {
                                             "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Something went wrong",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "object"
                                         }
                                     }
                                 }
@@ -499,7 +727,7 @@
                         "name": "collection",
                         "in":  "path",
                         "required": true,
-                        "schema":{
+                        "schema": {
                             "type": "string"
                         }
                     }
@@ -509,11 +737,29 @@
                         "description": "APIKey",
                         "content": {
                             "application/json": {
-                                "schema":{
+                                "schema": {
                                     "type": "object",
                                     "properties": {
-                                        "APIKey":{
+                                        "APIKey": {
                                             "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Something went wrong",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "object"
                                         }
                                     }
                                 }
@@ -538,8 +784,26 @@
                                 "schema":{
                                     "type": "object",
                                     "properties": {
-                                        "APIKey":{
+                                        "APIKey": {
                                             "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Something went wrong",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "object"
                                         }
                                     }
                                 }
@@ -549,16 +813,16 @@
                 }
             }
         },
-           "/git/status":{
+        "/git/status": {
             "get": {
-                "summary": "Get Tuttle configuration",
+                "summary": "Get status of all configured collections",
                 "x-constraints": {
                     "groups": ["dba"]
                 },
                 "operationId": "api:get-status",
                 "responses": {
                     "200": {
-                        "description": "GIT status",
+                        "description": "status of all configured collections",
                         "content": {
                             "application/xml":{
                                 "schema": {
@@ -659,21 +923,39 @@
                         "name": "collection",
                         "in":  "path",
                         "required": true,
-                        "schema":{
+                        "schema": {
                             "type": "string"
                         }
                     }
                 ],
                 "responses": {
-                    "200":{
-                        "description": "JSON dump of request",
+                    "200": {
+                        "description": "Lockfile removed",
                         "content": {
                             "application/json": {
-                                "schema":{
+                                "schema": {
                                     "type": "object",
                                     "properties": {
-                                        "message":{
+                                        "message": {
                                             "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Something went wrong",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "object"
                                         }
                                     }
                                 }
@@ -690,21 +972,39 @@
                         "name": "collection",
                         "in":  "path",
                         "required": true,
-                        "schema":{
+                        "schema": {
                             "type": "string"
                         }
                     }
                 ],
                 "responses": {
-                    "200":{
-                        "description": "JSON dump of request",
+                    "200": {
+                        "description": "Lockfile contents",
                         "content": {
                             "application/json": {
-                                "schema":{
+                                "schema": {
                                     "type": "object",
                                     "properties": {
-                                        "message":{
+                                        "message": {
                                             "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Something went wrong",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "object"
                                         }
                                     }
                                 }
@@ -719,15 +1019,33 @@
                 "summary": "Remove Lockfile",
                 "operationId": "api:lock-remove",
                 "responses": {
-                    "200":{
-                        "description": "JSON dump of request",
+                    "200": {
+                        "description": "Lockfile for the default collection removed",
                         "content": {
                             "application/json": {
-                                "schema":{
+                                "schema": {
                                     "type": "object",
                                     "properties": {
-                                        "message":{
+                                        "message": {
                                             "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Something went wrong",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "object"
                                         }
                                     }
                                 }
@@ -740,15 +1058,33 @@
                 "summary": "Print Lockfile",
                 "operationId": "api:lock-print",
                 "responses": {
-                    "200":{
-                        "description": "JSON dump of request",
+                    "200": {
+                        "description": "Contents of the lockfile of the default collection",
                         "content": {
                             "application/json": {
-                                "schema":{
+                                "schema": {
                                     "type": "object",
                                     "properties": {
-                                        "message":{
+                                        "message": {
                                             "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Something went wrong",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "object"
                                         }
                                     }
                                 }

--- a/src/api.json
+++ b/src/api.json
@@ -191,7 +191,7 @@
                 ],
                 "responses": {
                     "200":{
-                        "description": "JSON dump of request",
+                        "description": "Result of the incremental update",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -200,6 +200,21 @@
                                         "sha" : {
                                             "type" : "string"
                                         },
+                                        "message" : {
+                                            "type" : "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403":{
+                        "description": "Request cannot run",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties" : {
                                         "message" : {
                                             "type" : "string"
                                         }
@@ -231,7 +246,7 @@
                 ],
                 "responses": {
                     "200":{
-                        "description": "result of the update",
+                        "description": "Result of the incremental update of the default collection",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -240,6 +255,21 @@
                                         "sha" : {
                                             "type" : "string"
                                         },
+                                        "message" : {
+                                            "type" : "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403":{
+                        "description": "Request cannot run",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties" : {
                                         "message" : {
                                             "type" : "string"
                                         }

--- a/src/finish.xq
+++ b/src/finish.xq
@@ -28,5 +28,5 @@ else ((: copy example configuration when no backup was found :)
 sm:chmod(xs:anyURI($configuration-collection || $configuration-filename), "rw-r-----")
 ,
 (: set gid for API :)
-sm:chmod(xs:anyURI($target || "/modules/api.xq"), "rwxr-sr-x")
+sm:chmod(xs:anyURI($target || "/modules/api.xq"), "rwxr-xr-x")
 

--- a/src/index.html
+++ b/src/index.html
@@ -137,17 +137,18 @@
                     <fx-setvalue ref="instance('vars')/inprogress"></fx-setvalue>
                     <fx-send submission="config"></fx-send>
                 </fx-action>
-                <!--                <fx-setvalue event="submit-error"></fx-setvalue>-->
+                <fx-action event="submit-error">
+                    <fx-message>Udpate Failed!</fx-message>
+                    <fx-setvalue ref="instance('vars')/inprogress"></fx-setvalue>
+                </fx-action>
             </fx-submission>
 
             <fx-function signature="local:encode($input as xs:string) as xs:string" type="text/javascript">
                 return btoa(encodeURI($input));
             </fx-function>
-
         </fx-model>
 
         <div class="overlay {instance('vars')/loaded} {instance('vars')/inprogress}">
-            <!--            <span class="loader-26"></span>-->
             <div class="wrap-overlay">
                 <img src="images/Git_icon.svg" class="icon git"></img>
                 <div class="arrow">
@@ -176,8 +177,8 @@
                     </fx-trigger>
                 </section>
             </fx-case>
-            <fx-case id="repos">
 
+            <fx-case id="repos">
                 <fx-group>
                     <a class="docs" href="https://eeditiones.github.io/tuttle-doc" target="_blank">Documentation</a>
                     <h2>Git to DB<span class="small">import data from Git into eXist-db</span></h2>
@@ -190,7 +191,7 @@
                                 <span class="repoName"><a href="{@url}" target="_blank">{./@collection}</a></span>
                                 <fx-trigger>
                                     <button>
-                                        <span>full</span>
+                                        <span>Full</span>
                                     </button>
                                     <fx-confirm message="This action might be time-consuming. Do you want to proceed?">
                                         <fx-send submission="fetch"></fx-send>

--- a/src/modules/api.xq
+++ b/src/modules/api.xq
@@ -113,7 +113,7 @@ declare function api:get-hash($request as map(*)) as map(*) {
         }
     }
     catch * {
-        api:catch-api-error("api:get-hash", map {
+        api:catch-error("api:get-hash", map {
             "code": $err:code, "description": $err:description, "value": $err:value,
             "line": $err:line-number, "column": $err:column-number, "module": $err:module
         })
@@ -138,7 +138,7 @@ declare function api:lock-remove($request as map(*)) as map(*) {
         return map { "message": $message }
     }
     catch * {
-        api:catch-api-error("api:lock-remove", map {
+        api:catch-error("api:lock-remove", map {
             "code": $err:code, "description": $err:description, "value": $err:value,
             "line": $err:line-number, "column": $err:column-number, "module": $err:module
         })
@@ -160,7 +160,7 @@ declare function api:lock-print($request as map(*)) as map(*) {
         return map { "message": $message }
     }
     catch * {
-        api:catch-api-error("api:lock-print", map {
+        api:catch-error("api:lock-print", map {
             "code": $err:code, "description": $err:description, "value": $err:value,
             "line": $err:line-number, "column": $err:column-number, "module": $err:module
         })
@@ -225,7 +225,7 @@ declare %private function api:pull($config as map(*), $hash as xs:string?) as ma
         )
     }
     catch * {
-        api:catch-api-error("api:git-deploy", map {
+        api:catch-error("api:git-deploy", map {
             "code": $err:code, "description": $err:description, "value": $err:value,
             "line": $err:line-number, "column": $err:column-number, "module": $err:module
         })
@@ -292,7 +292,7 @@ declare function api:git-deploy($request as map(*)) as map(*) {
 
     }
     catch * {
-        api:catch-api-error("api:git-deploy", map {
+        api:catch-error("api:git-deploy", map {
             "code": $err:code, "description": $err:description, "value": $err:value,
             "line": $err:line-number, "column": $err:column-number, "module": $err:module
         })
@@ -312,7 +312,7 @@ declare function api:get-commits($request as map(*)) as map(*) {
         }
     }
     catch * {
-        api:catch-api-error("api:git-commits", map {
+        api:catch-error("api:git-commits", map {
             "code": $err:code, "description": $err:description, "value": $err:value,
             "line": $err:line-number, "column": $err:column-number, "module": $err:module
         })
@@ -332,7 +332,7 @@ declare function api:get-commits-default($request as map(*)) as map(*) {
         }
     }
     catch * {
-        api:catch-api-error("api:git-commits-default", map {
+        api:catch-error("api:git-commits-default", map {
             "code": $err:code, "description": $err:description, "value": $err:value,
             "line": $err:line-number, "column": $err:column-number, "module": $err:module
         })
@@ -440,7 +440,7 @@ declare function api:incremental($request as map(*)) as map(*) {
             )
     }
     catch * {
-        api:catch-api-error("api:incremental", map {
+        api:catch-error("api:incremental", map {
             "code": $err:code, "description": $err:description, "value": $err:value,
             "line": $err:line-number, "column": $err:column-number, "module": $err:module
         })
@@ -459,7 +459,7 @@ declare function api:api-keygen($request as map(*)) as map(*) {
         return map { "APIKey" : $apikey }
     }
     catch * {
-        api:catch-api-error("api:api-keygen", map {
+        api:catch-error("api:api-keygen", map {
             "code": $err:code, "description": $err:description, "value": $err:value,
             "line": $err:line-number, "column": $err:column-number, "module": $err:module
         })
@@ -503,7 +503,7 @@ declare function api:hook($request as map(*)) as map(*) {
             )
     }
     catch * {
-        api:catch-api-error("api:hook", map {
+        api:catch-error("api:hook", map {
             "code": $err:code, "description": $err:description, "value": $err:value,
             "line": $err:line-number, "column": $err:column-number, "module": $err:module
         })

--- a/src/modules/api.xq
+++ b/src/modules/api.xq
@@ -4,8 +4,6 @@ declare namespace api="http://exist-db.org/apps/tuttle/api";
 declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
 
 import module namespace roaster="http://e-editiones.org/roaster";
-import module namespace rutil="http://e-editiones.org/roaster/util";
-import module namespace errors="http://e-editiones.org/roaster/errors";
 import module namespace xmldb="http://exist-db.org/xquery/xmldb";
 import module namespace compression="http://exist-db.org/xquery/compression";
 

--- a/src/modules/api.xq
+++ b/src/modules/api.xq
@@ -115,7 +115,10 @@ declare function api:get-hash($request as map(*)) as map(*) {
         }
     }
     catch * {
-        roaster:response(500, "application/json", map { "message": $err:description })
+        api:catch-api-error("api:get-hash", map {
+            "code": $err:code, "description": $err:description, "value": $err:value,
+            "line": $err:line-number, "column": $err:column-number, "module": $err:module
+        })
     }
 };
 
@@ -137,7 +140,10 @@ declare function api:lock-remove($request as map(*)) as map(*) {
         return map { "message": $message }
     }
     catch * {
-        roaster:response(500, "application/json", map { "message": $err:description })
+        api:catch-api-error("api:lock-remove", map {
+            "code": $err:code, "description": $err:description, "value": $err:value,
+            "line": $err:line-number, "column": $err:column-number, "module": $err:module
+        })
     }
 };
 
@@ -156,7 +162,10 @@ declare function api:lock-print($request as map(*)) as map(*) {
         return map { "message": $message }
     }
     catch * {
-        roaster:response(500, "application/json", map { "message": $err:description })
+        api:catch-api-error("api:lock-print", map {
+            "code": $err:code, "description": $err:description, "value": $err:value,
+            "line": $err:line-number, "column": $err:column-number, "module": $err:module
+        })
     }
 };
 
@@ -218,13 +227,9 @@ declare %private function api:pull($config as map(*), $hash as xs:string?) as ma
         )
     }
     catch * {
-        util:log('error', 'Error occured while deploying ' || $err:description),
-        roaster:response(500, "application/json", map {
-            "message": $err:description,
-            "error": map {
-                "code": $err:code, "description": $err:description, "value": $err:value,
-                "line": $err:line-number, "column": $err:column-number, "module": $err:module
-            }
+        api:catch-api-error("api:git-deploy", map {
+            "code": $err:code, "description": $err:description, "value": $err:value,
+            "line": $err:line-number, "column": $err:column-number, "module": $err:module
         })
     }
 };
@@ -289,12 +294,9 @@ declare function api:git-deploy($request as map(*)) as map(*) {
 
     }
     catch * {
-        roaster:response(500, "application/json", map {
-            "message": $err:description,
-            "error": map {
-                "code": $err:code, "description": $err:description, "value": $err:value,
-                "line": $err:line-number, "column": $err:column-number, "module": $err:module
-            }
+        api:catch-api-error("api:git-deploy", map {
+            "code": $err:code, "description": $err:description, "value": $err:value,
+            "line": $err:line-number, "column": $err:column-number, "module": $err:module
         })
     }
 };
@@ -312,12 +314,10 @@ declare function api:get-commits($request as map(*)) as map(*) {
         }
     }
     catch * {
-        roaster:response(500, map {
-            "message": $err:description,
-            "code": $err:code, "value": $err:value,
-            "line": $err:line-number, "column": $err:column-number, "module": $err:module,
-            "request": map:remove($request, 'spec')
-         })
+        api:catch-api-error("api:git-commits", map {
+            "code": $err:code, "description": $err:description, "value": $err:value,
+            "line": $err:line-number, "column": $err:column-number, "module": $err:module
+        })
     }
 };
 
@@ -334,11 +334,9 @@ declare function api:get-commits-default($request as map(*)) as map(*) {
         }
     }
     catch * {
-        roaster:response(500, map{
-            "message": $err:description,
-            "code": $err:code, "value": $err:value,
-            "line": $err:line-number, "column": $err:column-number, "module": $err:module,
-            "request": map:remove($request, 'spec')
+        api:catch-api-error("api:git-commits-default", map {
+            "code": $err:code, "description": $err:description, "value": $err:value,
+            "line": $err:line-number, "column": $err:column-number, "module": $err:module
         })
     }
 };
@@ -444,12 +442,9 @@ declare function api:incremental($request as map(*)) as map(*) {
             )
     }
     catch * {
-        roaster:response(500, "application/json", map {
-            "message": $err:description,
-            "error": map {
-                "code": $err:code, "description": $err:description, "value": $err:value,
-                "line": $err:line-number, "column": $err:column-number, "module": $err:module
-            }
+        api:catch-api-error("api:incremental", map {
+            "code": $err:code, "description": $err:description, "value": $err:value,
+            "line": $err:line-number, "column": $err:column-number, "module": $err:module
         })
     }
 };
@@ -466,7 +461,10 @@ declare function api:api-keygen($request as map(*)) as map(*) {
         return map { "APIKey" : $apikey }
     }
     catch * {
-        roaster:response(500, "application/json", map { "message": $err:description })
+        api:catch-api-error("api:api-keygen", map {
+            "code": $err:code, "description": $err:description, "value": $err:value,
+            "line": $err:line-number, "column": $err:column-number, "module": $err:module
+        })
     }
 };
 
@@ -507,10 +505,12 @@ declare function api:hook($request as map(*)) as map(*) {
             )
     }
     catch * {
-        roaster:response(500, "application/json", map { "message": $err:description })
+        api:catch-api-error("api:hook", map {
+            "code": $err:code, "description": $err:description, "value": $err:value,
+            "line": $err:line-number, "column": $err:column-number, "module": $err:module
+        })
     }
 };
-
 
 (:~
  : This is used as an error-handler in the API definition
@@ -528,6 +528,14 @@ declare function api:handle-error($error as map(*)) as element(html) {
             <p>{$error?description}</p>
         </body>
     </html>
+};
+
+declare %private
+function api:catch-error($function, $error as map(*)) {
+    util:log('error', ($function, ': [', $error?code, '] ', $error?description)),
+    roaster:response(500, "application/json", map {
+        "message": $error?description, "error": $error
+    })
 };
 
 declare %private function api:get-default-collection-config() as map(*)? {

--- a/src/modules/api.xq
+++ b/src/modules/api.xq
@@ -421,7 +421,6 @@ declare function api:incremental($request as map(*)) as map(*) {
                 return
                     if (exists($all-errored-operations)) then (
                         roaster:response(500, "application/json", map {
-                            "message": "incremental update failed", 
                             "hash": config:deployed-sha($config?path),
                             "message": "ended with errors",
                             "changes": $incremental,

--- a/test/tuttle.js
+++ b/test/tuttle.js
@@ -184,10 +184,10 @@ export default () =>
             const resultPromise = axios.get('git/status', { auth });
             await assert.doesNotReject(resultPromise);
         
-            const stagingPromise = axios.get(`git/tuttle-sample-data`, {}, { auth });
+            const stagingPromise = axios.get('git/tuttle-sample-data', { auth });
             await assert.doesNotReject(stagingPromise, 'The request should succeed');
-        
-            const deployPromise = axios.post(`git/tuttle-sample-data`, {}, { auth });
+
+            const deployPromise = axios.post('git/tuttle-sample-data', {}, { auth });
             await assert.doesNotReject(deployPromise, 'The request should succeed');
         
             const repoXML = await getResource('/db/apps/tuttle-sample-data/repo.xml');


### PR DESCRIPTION
API calls that cannot be fulfilled to do issues with the request or internal errors now do return status codes that indicate problems (specifically 403 and 500).

The bundled callback `cb:check-version` will now safely update packages that were already installed in exist-db